### PR TITLE
Lifetimes support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,16 +15,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "diesel"
-version = "2.1.6"
+name = "darling"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff236accb9a5069572099f0b350a92e9560e8e63a9b8d546162f4a5e03026bb2"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diesel"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d6dcd069e7b5fe49a302411f759d4cf1cf2c27fe798ef46fb8baefc053dd2b"
 dependencies = [
  "bitflags",
  "byteorder",
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "serde_json",
 ]
 
 [[package]]
@@ -48,11 +84,12 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.4"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14701062d6bed917b5c7103bdffaee1e4609279e240488ad24e7bd979ca6866c"
+checksum = "59de76a222c2b8059f789cbe07afbfd8deb8c31dd0bc2a21f85e256c1def8259"
 dependencies = [
  "diesel_table_macro_syntax",
+ "dsl_auto_type",
  "proc-macro2",
  "quote",
  "syn",
@@ -60,18 +97,50 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
  "syn",
 ]
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0892a17df262a24294c382f0d5997571006e7a4348b4327557c4ff1cd4a8bccc"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "itoa"
@@ -142,6 +211,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ proc-macro = true
 heck = "0.5.0"
 quote = "1"
 syn = { version = "2", default-features = false, features = ["parsing", "proc-macro", "derive"] }
+
+[dev-dependencies]
+syn = { version = "2", features = ["full", "extra-traits"] }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ This gets tedious quickly so this create does it for you. So with this crate you
 
 ```rust
 use diesel::sql_types::Jsonb;
-use diesel::{FromSqlRow, AsExpression};
+use diesel::deserialize::FromSqlRow;
+use diesel::expression::AsExpression;
 use diesel_json_derive::DieselJsonb;
 use serde::{Deserialize, Serialize};
 

--- a/diesel-json-derive-test/Cargo.toml
+++ b/diesel-json-derive-test/Cargo.toml
@@ -6,7 +6,7 @@ description = "A test project for diesel-json-derive-macro"
 publish = false
 
 [dependencies]
-serde = { version = "1.0.202", features = ["derive"] }
+serde = { version = "^1.0", features = ["derive"] }
 diesel-json-derive = { path = "../" }
-diesel = { version = "2.1.6", features = ["postgres"] }
-serde_json = "1.0.117"
+diesel = { version = "^2.2", features = ["postgres", "serde_json"] }
+serde_json = "^1.0"

--- a/diesel-json-derive-test/src/main.rs
+++ b/diesel-json-derive-test/src/main.rs
@@ -1,5 +1,7 @@
 mod schema;
 
+use std::borrow::Cow;
+
 use diesel::prelude::*;
 use diesel::sql_types::Jsonb;
 use diesel::{FromSqlRow, AsExpression};
@@ -12,15 +14,22 @@ use serde::{Deserialize, Serialize};
 #[diesel(table_name = crate::schema::foo)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id))]
-struct Foo {
+struct Foo<'a> {
     id: String,
     bar: Bar,
+    bar_with_cowed_lifetimes: BarWithCowedLifetimes<'a>,
 }
 
 #[derive(Debug, Serialize, Deserialize, AsExpression, FromSqlRow, DieselJsonb)]
 #[diesel(sql_type = Jsonb)]
 struct Bar {
     x: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, AsExpression, FromSqlRow, DieselJsonb)]
+#[diesel(sql_type = Jsonb)]
+struct BarWithCowedLifetimes<'a> {
+    x: Cow<'a, str>,
 }
 
 fn main() {

--- a/diesel-json-derive-test/src/schema.rs
+++ b/diesel-json-derive-test/src/schema.rs
@@ -4,5 +4,6 @@ diesel::table! {
     foo (id) {
         id -> Text,
         bar -> Jsonb,
+        bar_with_cowed_lifetimes -> Jsonb,
     }
 }


### PR DESCRIPTION
I norder to support struct like this:

```rust
#[derive(Debug, Serialize, Deserialize, AsExpression, FromSqlRow, DieselJsonb)]
#[diesel(sql_type = Jsonb)]
struct BarWithCowedLifetimes<'a> {
    x: Cow<'a, str>,
}
```

Also lifetimes must be inherited.